### PR TITLE
Use latest tag for image paths without tag

### DIFF
--- a/TestContainers.Tests/ContainerTests/ContainerTests.cs
+++ b/TestContainers.Tests/ContainerTests/ContainerTests.cs
@@ -36,6 +36,22 @@ namespace TestContainers.Tests.ContainerTests
             Assert.Equal("your.custom", label.Key);
             Assert.Equal("label", label.Value);
         }
+
+        [Theory]
+        [InlineData("alpine:latest", "alpine:latest")]
+        [InlineData("alpine", "alpine:latest")]
+        [InlineData("alpine:hello", "alpine:hello")]
+        [InlineData("test.de:55/alpine:latest", "test.de:55/alpine:latest")]
+        [InlineData("test.de:55/alpine", "test.de:55/alpine:latest")]
+        public void WithImage_ExtractFromImageAndTag(string path, string tag)
+        {
+            var container = new GenericContainerBuilder<Container>()
+                .Begin()
+                .WithImage(path)
+                .Build();
+            
+            Assert.Equal(tag, container.DockerImageName);
+        }
     }
 
 }

--- a/TestContainers/Core/Builders/ContainerBuilder.cs
+++ b/TestContainers/Core/Builders/ContainerBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using TestContainers.Core.Containers;
 using Docker.DotNet;
 
@@ -27,6 +28,11 @@ namespace TestContainers.Core.Builders
         {
             fn = FnUtils.Compose(fn, (container) =>
             {
+                var tag = dockerImageName.Split(':').Last();
+                if (dockerImageName == tag || tag.Contains("/"))
+                {
+                    dockerImageName = $"{dockerImageName}:latest";
+                }
                 container.DockerImageName = dockerImageName;
                 return container;
             });

--- a/TestContainers/Core/Containers/Container.cs
+++ b/TestContainers/Core/Containers/Container.cs
@@ -58,10 +58,7 @@ namespace TestContainers.Core.Containers
             await WaitUntilContainerStarted();
         }
 
-        private void Progress_ProgressChanged(object sender, JSONMessage e)
-        {
-            throw new NotImplementedException();
-        }
+        
 
         protected virtual async Task WaitUntilContainerStarted()
         {
@@ -88,12 +85,14 @@ namespace TestContainers.Core.Containers
 
             });
 
+            var tag = DockerImageName.Split(':').Last();
+            var imagesCreateParameters = new ImagesCreateParameters
+            {
+                FromImage = DockerImageName,
+                Tag = tag,
+            };
             await _dockerClient.Images.CreateImageAsync(
-                new ImagesCreateParameters
-                {
-                    FromImage = DockerImageName,
-                    Tag = DockerImageName.Split(':').Last(),
-                },
+                imagesCreateParameters,
                 new AuthConfig(),
                 progress,
                 CancellationToken.None);


### PR DESCRIPTION
Match image pull behaviour of `docker pull`.