### PR TITLE
Don't use deprecated GetContainerLogsAsync

### DIFF
--- a/TestContainers/Core/Containers/Container.cs
+++ b/TestContainers/Core/Containers/Container.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet;
@@ -13,6 +14,7 @@ namespace TestContainers.Core.Containers
 {
     public class Container
     {
+        private static readonly UTF8Encoding Utf8EncodingWithoutBom = new UTF8Encoding(false);
         readonly DockerClient _dockerClient;
         string _containerId { get; set; }
         public string DockerImageName { get; set; }
@@ -35,24 +37,29 @@ namespace TestContainers.Core.Containers
 
         async Task TryStart()
         {
-            var progress = new Progress<string>(m =>
-            {
-                Debug.WriteLine(m);
-
-                // Debug.WriteLineIf(m.Error != null, m.ErrorMessage);
-            });
-
             var started = await _dockerClient.Containers.StartContainerAsync(_containerId, new ContainerStartParameters());
 
             if(started)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                await _dockerClient.Containers.GetContainerLogsAsync(_containerId, new ContainerLogsParameters
+                using (var logs = await _dockerClient.Containers.GetContainerLogsAsync(_containerId,
+                    new ContainerLogsParameters
+                    {
+                        ShowStderr = true,
+                        ShowStdout = true,
+                    }, default(CancellationToken)))
                 {
-                    ShowStderr = true,
-                    ShowStdout = true,
-                }, default(CancellationToken), progress: progress);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    using (logs)
+                    {
+                        using (var reader = new StreamReader(logs, Utf8EncodingWithoutBom))
+                        {
+                            string nextLine;
+                            while ((nextLine = await reader.ReadLineAsync()) != null)
+                            {
+                                Debug.WriteLine(nextLine);
+                            }
+                        }
+                    }
+                }
             }
 
             await WaitUntilContainerStarted();

--- a/TestContainers/Core/Containers/Container.cs
+++ b/TestContainers/Core/Containers/Container.cs
@@ -48,15 +48,12 @@ namespace TestContainers.Core.Containers
                         ShowStdout = true,
                     }, default(CancellationToken)))
                 {
-                    using (logs)
+                    using (var reader = new StreamReader(logs, Utf8EncodingWithoutBom))
                     {
-                        using (var reader = new StreamReader(logs, Utf8EncodingWithoutBom))
+                        string nextLine;
+                        while ((nextLine = await reader.ReadLineAsync()) != null)
                         {
-                            string nextLine;
-                            while ((nextLine = await reader.ReadLineAsync()) != null)
-                            {
-                                Debug.WriteLine(nextLine);
-                            }
+                            Debug.WriteLine(nextLine);
                         }
                     }
                 }

--- a/TestContainers/Core/Containers/Container.cs
+++ b/TestContainers/Core/Containers/Container.cs
@@ -14,7 +14,7 @@ namespace TestContainers.Core.Containers
 {
     public class Container
     {
-        private static readonly UTF8Encoding Utf8EncodingWithoutBom = new UTF8Encoding(false);
+        static readonly UTF8Encoding Utf8EncodingWithoutBom = new UTF8Encoding(false);
         readonly DockerClient _dockerClient;
         string _containerId { get; set; }
         public string DockerImageName { get; set; }


### PR DESCRIPTION
Tried to get rid of the deprecation warning. The encoding is the same as in the deprecate function.