### PR TITLE
WIP: Use exact URI as in next Docker.DotNet

### DIFF
--- a/TestContainers/DockerClient/UnixSocketClientProviderStrategy.cs
+++ b/TestContainers/DockerClient/UnixSocketClientProviderStrategy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using Docker.DotNet;
 
 namespace TestContainers
@@ -7,7 +6,7 @@ namespace TestContainers
     public class UnixSocketClientProviderStrategy : DockerClientProviderStrategy
     {
         protected override DockerClientConfiguration Config { get; } =
-            new DockerClientConfiguration(new Uri("unix:///var/run/docker.sock"));
+            new DockerClientConfiguration(new Uri("unix:/var/run/docker.sock"));
 
         protected override bool IsApplicable() => EnvironmentHelper.IsOSX() || EnvironmentHelper.IsLinux();
 


### PR DESCRIPTION
Adjust the URI as seen in https://github.com/Microsoft/Docker.DotNet/commit/21832ee6b822671f9ca5ab4ef056e4b37a5f1e3d (unreleased as of now)

Though this hopefully is just a minor optimization (/// should be folded to /), I hope that appveyor becomes useable again. I do fear however that they either use a non-standard path or set the wron access-rights… hence WIP.