### PR TITLE
Remove DB-dependencies from testcontainers

### DIFF
--- a/TestContainers.Tests/TestContainers.Tests.csproj
+++ b/TestContainers.Tests/TestContainers.Tests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+    <PackageReference Include="Npgsql" Version="4.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestContainers\TestContainers.csproj" />

--- a/TestContainers/Core/Containers/DatabaseContainer.cs
+++ b/TestContainers/Core/Containers/DatabaseContainer.cs
@@ -4,7 +4,7 @@ namespace TestContainers.Core.Containers
     {
         protected int GetStartupTimeoutSeconds => 120;
 
-        protected int GetConnectTImeoutSeconds => 120;
+        protected int GetConnectTimeoutSeconds => 10;
 
         public DatabaseContainer() : base()
         {
@@ -12,12 +12,10 @@ namespace TestContainers.Core.Containers
         }
 
         public virtual string DatabaseName { get; set; }
-        public virtual string ConnectionString { get; }
+        public abstract string ConnectionString { get; }
 
         public virtual string UserName { get; set; }
 
         public virtual string Password { get; set; }
-
-        protected virtual string TestQueryString { get; }
     }
 }

--- a/TestContainers/Core/Containers/MySqlContainer.cs
+++ b/TestContainers/Core/Containers/MySqlContainer.cs
@@ -1,19 +1,18 @@
 using System;
-using System.Data.Common;
 using System.Reflection;
-using System.Threading.Tasks;
-using Polly;
 
 namespace TestContainers.Core.Containers
 {
-    public sealed class MySqlContainer : DatabaseContainer
+    public sealed class MySqlContainer : SqlDatabaseContainer
     {
         public const string NAME = "mysql";
         public const string IMAGE = "mysql";
         public const int MYSQL_PORT = 3306;
-        private readonly Type _mySqlConnection;
-        private readonly Type _mySqlCommand;
-        private readonly Type _mySqlException;
+        protected override Type ConnectionType { get; }
+
+        protected override Type ExceptionType { get; }
+
+        protected override Type CommandType { get; }
 
         public override string DatabaseName => base.DatabaseName ?? _databaseName;
 
@@ -28,43 +27,12 @@ namespace TestContainers.Core.Containers
         public MySqlContainer() : base()
         {
             var assembly = Assembly.Load("MySql.Data");
-            _mySqlConnection = assembly.GetType("MySql.Data.MySqlClient.MySqlConnection", true);
-            _mySqlCommand = assembly.GetType("MySql.Data.MySqlClient.MySqlCommand", true);
-            _mySqlException = assembly.GetType("MySql.Data.MySqlClient.MySqlException", true);
+            ConnectionType = assembly.GetType("MySql.Data.MySqlClient.MySqlConnection", true);
+            CommandType = assembly.GetType("MySql.Data.MySqlClient.MySqlCommand", true);
+            ExceptionType = assembly.GetType("MySql.Data.MySqlClient.MySqlException", true);
         }
-
-        int GetMappedPort(int portNo) => portNo;
-
 
         public override string ConnectionString => $"Server={GetDockerHostIpAddress()};UID={UserName};pwd={Password};SslMode=none;";
 
-        protected override string TestQueryString => "SELECT 1";
-
-        protected override async Task WaitUntilContainerStarted()
-        {
-            await base.WaitUntilContainerStarted();
-
-            var connection = (DbConnection) Activator.CreateInstance(_mySqlConnection, ConnectionString);
-
-            var result = await Policy
-                .TimeoutAsync(TimeSpan.FromMinutes(2))
-                .WrapAsync(Policy
-                    .Handle<Exception>(e => _mySqlException.IsInstanceOfType(e))
-                    .WaitAndRetryForeverAsync(
-                        iteration => TimeSpan.FromSeconds(10)))
-                .ExecuteAndCaptureAsync(async () =>
-                {
-                    await connection.OpenAsync();
-
-                    var cmd = (DbCommand) Activator.CreateInstance(_mySqlCommand, TestQueryString, connection);
-                    await cmd.ExecuteScalarAsync();
-                });
-
-            if (result.Outcome == OutcomeType.Failure)
-            {
-                connection.Dispose();
-                throw new Exception(result.FinalException.Message);
-            }
-        }
     }
 }

--- a/TestContainers/Core/Containers/PostgreSqlContainer.cs
+++ b/TestContainers/Core/Containers/PostgreSqlContainer.cs
@@ -1,19 +1,18 @@
 using System;
-using System.Data.Common;
 using System.Reflection;
-using System.Threading.Tasks;
-using Polly;
 
 namespace TestContainers.Core.Containers
 {
-    public sealed class PostgreSqlContainer : DatabaseContainer
+    public sealed class PostgreSqlContainer : SqlDatabaseContainer
     {
         public const string IMAGE = "postgres";
         public const string DEFAULT_TAG = "9.6.8";
         public const int POSTGRESQL_PORT = 5432;
-        private readonly Type _npgsqlConnection;
-        private readonly Type _npgsqlCommand;
-        private readonly Type _npgsqlException;
+        protected override Type ConnectionType { get; }
+
+        protected override Type ExceptionType { get; }
+
+        protected override Type CommandType { get; }
 
         public override string DatabaseName => base.DatabaseName ?? _databaseName;
 
@@ -28,40 +27,11 @@ namespace TestContainers.Core.Containers
         public PostgreSqlContainer() : base()
         {
             var assembly = Assembly.Load("Npgsql");
-            _npgsqlConnection = assembly.GetType("Npgsql.NpgsqlConnection", true);
-            _npgsqlCommand = assembly.GetType("Npgsql.NpgsqlCommand", true);
-            _npgsqlException = assembly.GetType("Npgsql.NpgsqlException", true);
+            ConnectionType = assembly.GetType("Npgsql.NpgsqlConnection", true);
+            CommandType = assembly.GetType("Npgsql.NpgsqlCommand", true);
+            ExceptionType = assembly.GetType("Npgsql.NpgsqlException", true);
         }
 
         public override string ConnectionString => $"Host={GetDockerHostIpAddress()};Username={UserName};pwd={Password}";
-
-        protected override string TestQueryString => "SELECT 1";
-
-        protected override async Task WaitUntilContainerStarted()
-        {
-            await base.WaitUntilContainerStarted();
-
-            var connection = (DbConnection) Activator.CreateInstance(_npgsqlConnection, ConnectionString);
-
-            var result = await Policy
-                .TimeoutAsync(TimeSpan.FromMinutes(2))
-                .WrapAsync(Policy
-                    .Handle<Exception>(e => _npgsqlException.IsInstanceOfType(e))
-                    .WaitAndRetryForeverAsync(
-                        iteration => TimeSpan.FromSeconds(10)))
-                .ExecuteAndCaptureAsync(async () =>
-                {
-                    await connection.OpenAsync();
-
-                    var cmd = (DbCommand) Activator.CreateInstance(_npgsqlCommand, TestQueryString, connection);
-                    await cmd.ExecuteScalarAsync();
-                });
-
-            if (result.Outcome == OutcomeType.Failure)
-            {
-                connection.Dispose();
-                throw new Exception(result.FinalException.Message);
-            }
-        }
     }
 }

--- a/TestContainers/Core/Containers/RedisContainer.cs
+++ b/TestContainers/Core/Containers/RedisContainer.cs
@@ -1,13 +1,35 @@
-﻿using Polly;
-using System;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
-using StackExchange.Redis;
 using System.Linq;
+using System.Reflection;
+using Polly;
 
 namespace TestContainers.Core.Containers
 {
     public sealed class RedisContainer : DatabaseContainer
     {
+        private readonly Func<string, TextWriter, Task> _connectAsync;
+        private readonly Type _redisConnectionException;
+
+        public RedisContainer() : base()
+        {
+            var assembly = Assembly.Load("StackExchange.Redis");
+            var connectionMultiplexer = assembly.GetType("StackExchange.Redis.ConnectionMultiplexer", true);
+            var connectAsync = connectionMultiplexer
+                .GetMethod("ConnectAsync", new[] {typeof(string), typeof(TextWriter)});
+            if (connectAsync == null)
+            {
+                throw new InvalidOperationException(
+                    "ConnectionMultiplexer is lacking procedure Task<ConnectionMultiplexer> ConnectAsync(string, TextWriter)");
+            }
+
+            _connectAsync = (Func<string, TextWriter, Task>) connectAsync
+                .CreateDelegate(typeof(Func<string, TextWriter, Task>));
+
+            _redisConnectionException = assembly.GetType("StackExchange.Redis.RedisConnectionException", true);
+        }
+
         public override string ConnectionString
         {
             get
@@ -25,14 +47,13 @@ namespace TestContainers.Core.Containers
             await base.WaitUntilContainerStarted();
 
             var policyResult = await Policy
-               .TimeoutAsync(TimeSpan.FromMinutes(2))
-               .WrapAsync(Policy
-                   .Handle<RedisConnectionException>()
-                   .WaitAndRetryForeverAsync(
-                       iteration => TimeSpan.FromSeconds(10),
-                       (exception, timespan) => Console.WriteLine(exception.Message)))
-               .ExecuteAndCaptureAsync(() =>
-                   ConnectionMultiplexer.ConnectAsync(ConnectionString));
+                .TimeoutAsync(TimeSpan.FromMinutes(2))
+                .WrapAsync(Policy
+                    .Handle<Exception>(e => _redisConnectionException.IsInstanceOfType(e))
+                    .WaitAndRetryForeverAsync(
+                        iteration => TimeSpan.FromSeconds(10),
+                        (exception, timespan) => Console.WriteLine(exception.Message)))
+                .ExecuteAndCaptureAsync(() => _connectAsync(ConnectionString, null));
 
             if (policyResult.Outcome == OutcomeType.Failure)
                 throw new Exception(policyResult.FinalException.Message);

--- a/TestContainers/Core/Containers/SqlDatabaseContainer.cs
+++ b/TestContainers/Core/Containers/SqlDatabaseContainer.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Polly;
+
+namespace TestContainers.Core.Containers
+{
+    public abstract class SqlDatabaseContainer : DatabaseContainer
+    {
+        protected abstract Type ConnectionType { get; }
+        protected abstract Type ExceptionType { get; }
+        protected abstract Type CommandType { get; }
+
+        public string TestQueryString { get; set; } = "SELECT 1";
+
+        protected override async Task WaitUntilContainerStarted()
+        {
+            await base.WaitUntilContainerStarted();
+
+            var connection = CreateConnection();
+
+            var result = await Policy
+                .TimeoutAsync(TimeSpan.FromSeconds(GetStartupTimeoutSeconds))
+                .WrapAsync(Policy
+                    .Handle<Exception>(e => ExceptionType.IsInstanceOfType(e))
+                    .WaitAndRetryForeverAsync(
+                        iteration => TimeSpan.FromSeconds(GetConnectTimeoutSeconds)))
+                .ExecuteAndCaptureAsync(async () =>
+                {
+                    await connection.OpenAsync();
+
+                    using (var cmd = CreateTestCommand(connection))
+                    {
+                        await cmd.ExecuteScalarAsync();
+                    }
+                });
+
+            if (result.Outcome == OutcomeType.Failure)
+            {
+                connection.Dispose();
+                throw new Exception(result.FinalException.Message);
+            }
+        }
+
+        protected virtual DbConnection CreateConnection()
+        {
+            return (DbConnection) Activator.CreateInstance(ConnectionType, ConnectionString);
+        }
+
+        protected virtual DbCommand CreateTestCommand(DbConnection connection)
+        {
+            return (DbCommand) Activator.CreateInstance(CommandType, TestQueryString, connection);
+        }
+    }
+}

--- a/TestContainers/TestContainers.csproj
+++ b/TestContainers/TestContainers.csproj
@@ -23,15 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Docker.Dotnet" Version="3.125.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Npgsql" Version="4.0.2" />
     <PackageReference Include="Polly" Version="6.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="MySql.Data" Version="6.9.11" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
-  </ItemGroup>
+    
 </Project>


### PR DESCRIPTION
You said in #28 that you would want to try to keep everything in one assembly. Even though I am undecided whether or not I like the way reflection has to be used to archive this. This would be an option where exceptions are only thrown when the class really is instantiated and not during static initialization.

RabbitMQ needs more attention because you return a connection and I don't want to erase the correct type there. I also hate that you can't change the return-type when overriding methods in C#.