### PR TITLE
Recover exception details to help debugging

### DIFF
--- a/TestContainers/Core/Containers/PostgreSqlContainer.cs
+++ b/TestContainers/Core/Containers/PostgreSqlContainer.cs
@@ -48,7 +48,7 @@ namespace TestContainers.Core.Containers
             if (result.Outcome == OutcomeType.Failure)
             {
                 connection.Dispose();
-                throw new Exception(result.FinalException.Message);
+                throw new Exception(result.FinalException.Message, result.FinalException);
             }
         }
     }


### PR DESCRIPTION
`throw new Exception(result.FinalException.Message);`
will only rethrow the exception message and the rich stacktrace that will help debug issues is completely lost, leaving developers scratching their heads.

Changing the line to `throw new Exception(result.FinalException.Message, result.FinalException);` will output rich stacktrace to help devs debug their own issues better.