### PR TITLE
Handle `System.Net.Sockets.SocketException : Connection refused`

### DIFF
--- a/TestContainers/Core/Containers/PostgreSqlContainer.cs
+++ b/TestContainers/Core/Containers/PostgreSqlContainer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Npgsql;
 using Polly;
@@ -35,6 +36,7 @@ namespace TestContainers.Core.Containers
                 .TimeoutAsync(TimeSpan.FromMinutes(2))
                 .WrapAsync(Policy
                     .Handle<NpgsqlException>()
+                    .Or<SocketException>()
                     .WaitAndRetryForeverAsync(
                         iteration => TimeSpan.FromSeconds(10)))
                 .ExecuteAndCaptureAsync(async () =>

--- a/TestContainers/Core/Containers/PostgreSqlContainer.cs
+++ b/TestContainers/Core/Containers/PostgreSqlContainer.cs
@@ -52,6 +52,7 @@ namespace TestContainers.Core.Containers
                 connection.Dispose();
                 throw new Exception(result.FinalException.Message);
             }
+            
         }
     }
 }


### PR DESCRIPTION
Sometimes, in some situations, instead of a `NgpsqlException`, waiting for the postgres container to start may throw `System.Net.Sockets.SocketException : Connection refused` instead if the postgres instance in the container hasn't even started.

This is the exception thrown when this happens:
```
Error Message:
 System.Exception : Connection refused
---- System.Net.Sockets.SocketException : Connection refused
Stack Trace:
   at TenantManagement.Tests.Fixtures.MyPostgreSqlContainer.WaitUntilContainerStarted() in /tvlk-ecb/tvlk-ecb/tests/TenantManagement.Tests/Fixtures/MyPostgresContainer.cs:line 62
   at TestContainers.Core.Containers.Container.TryStart()
   at TestContainers.Core.Containers.Container.Start()
----- Inner Stack Trace -----
   at System.Net.Sockets.Socket.BeginConnectEx(EndPoint remoteEP, Boolean flowContext, AsyncCallback callback, Object state)
   at System.Net.Sockets.Socket.UnsafeBeginConnect(EndPoint remoteEP, AsyncCallback callback, Object state, Boolean flowContext)
   at System.Net.Sockets.Socket.BeginConnect(EndPoint remoteEP, AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl[TArg1](Func`4 beginMethod, Func`2 endFunction, Action`1 endAction, TArg1 arg1, Object state, TaskCreationOptions creationOptions)
   at Npgsql.NpgsqlConnector.ConnectAsync(NpgsqlTimeout timeout, CancellationToken cancellationToken) in C:\projects\npgsql\src\Npgsql\NpgsqlConnector.cs:line 770
   at Npgsql.NpgsqlConnector.RawOpen(NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken) in C:\projects\npgsql\src\Npgsql\NpgsqlConnector.cs:line 550
   at Npgsql.NpgsqlConnector.Open(NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken) in C:\projects\npgsql\src\Npgsql\NpgsqlConnector.cs:line 414
   at Npgsql.ConnectorPool.AllocateLong(NpgsqlConnection conn, NpgsqlTimeout timeout, Boolean async, CancellationToken cancellationToken) in C:\projects\npgsql\src\Npgsql\ConnectorPool.cs:line 246
   at Npgsql.NpgsqlConnection.<>c__DisplayClass32_0.<<Open>g__OpenLong|0>d.MoveNext() in C:\projects\npgsql\src\Npgsql\NpgsqlConnection.cs:line 301
--- End of stack trace from previous location where exception was thrown ---
   at TenantManagement.Tests.Fixtures.MyPostgreSqlContainer.<>c__DisplayClass16_0.<<WaitUntilContainerStarted>b__1>d.MoveNext() in /tvlk-ecb/tvlk-ecb/tests/TenantManagement.Tests/Fixtures/MyPostgresContainer.cs:line 53
--- End of stack trace from previous location where exception was thrown ---
   at Polly.RetrySyntaxAsync.<>c__DisplayClass40_1.<<WaitAndRetryForeverAsync>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Polly.Retry.RetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, IEnumerable`1 shouldRetryExceptionPredicates, IEnumerable`1 shouldRetryResultPredicates, Func`1 policyStateFactory, Boolean continueOnCapturedContext)
   at Polly.Retry.RetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, IEnumerable`1 shouldRetryExceptionPredicates, IEnumerable`1 shouldRetryResultPredicates, Func`1 policyStateFactory, Boolean continueOnCapturedContext)
   at Polly.Policy.ExecuteAsyncInternal(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Polly.Wrap.PolicyWrapEngine.<>c__DisplayClass9_0.<<ImplementationAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Polly.Policy.<>c__DisplayClass213_1.<<TimeoutAsync>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Polly.Timeout.TimeoutEngine.ImplementationAsync[TResult](Func`3 action, Context context, Func`2 timeoutProvider, TimeoutStrategy timeoutStrategy, Func`4 onTimeoutAsync, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Polly.Timeout.TimeoutEngine.ImplementationAsync[TResult](Func`3 action, Context context, Func`2 timeoutProvider, TimeoutStrategy timeoutStrategy, Func`4 onTimeoutAsync, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Polly.Policy.ExecuteAsyncInternal(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Polly.Wrap.PolicyWrapEngine.ImplementationAsync(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext, IAsyncPolicy outerPolicy, IAsyncPolicy innerPolicy)
   at Polly.Policy.ExecuteAsyncInternal(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
   at Polly.Policy.ExecuteAndCaptureAsync(Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
```

Adding `Or<SocketException` to the policy reacts to this error appropriately