### PR TITLE
Adding link to nuget package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/b20um5dc0ikf8cme/branch/master?svg=true)](https://ci.appveyor.com/project/swissarmykirpan/testcontainers-dotnet-ak6r1/branch/master)
 
 [![Coverage Status](https://coveralls.io/repos/github/testcontainers/testcontainers-dotnet/badge.svg?branch=)](https://coveralls.io/github/testcontainers/testcontainers-dotnet?branch=master)
+
+Nuget package can be found [here](https://www.nuget.org/packages/TestContainers/).


### PR DESCRIPTION
It's not immediately obvious that nuget package for the project exists (given that it has different name).