### PR TITLE
Exec Command Bug Fix

### DIFF
--- a/TestContainers.Tests/ContainerTests/ContainerTests.cs
+++ b/TestContainers.Tests/ContainerTests/ContainerTests.cs
@@ -49,8 +49,29 @@ namespace TestContainers.Tests.ContainerTests
                 .Begin()
                 .WithImage(path)
                 .Build();
-            
+
             Assert.Equal(tag, container.DockerImageName);
+        }
+
+        [Fact]
+        public async Task WithExecCommand()
+        {
+            var container = new GenericContainerBuilder<Container>()
+                .Begin()
+                .WithImage("alpine:latest")
+                .Build();
+
+            await container.Start();
+
+            var execCommand = new[]
+            {
+                "/bin/sh",
+                "-c",
+                "ls"
+            };
+
+            await container.ExecuteCommand(execCommand);
+            await container.Stop();
         }
     }
 }

--- a/TestContainers/Core/Containers/Container.cs
+++ b/TestContainers/Core/Containers/Container.cs
@@ -189,7 +189,7 @@ namespace TestContainers.Core.Containers
 
             var response = await _dockerClient.Containers.ExecCreateContainerAsync(_containerId, containerExecCreateParams);
 
-            await _dockerClient.Containers.StartContainerExecAsync(_containerId);
+            await _dockerClient.Containers.StartContainerExecAsync(response.ID);
         }
 
         public string GetDockerHostIpAddress()


### PR DESCRIPTION
`containerId` was being passed to `StartContainerExecAsync` instead of the `ExecCreateContainerAsync` `responseId`