### PR TITLE
[Breaking] New container interface

### DIFF
--- a/src/TestContainers/Containers/IContainer.cs
+++ b/src/TestContainers/Containers/IContainer.cs
@@ -11,7 +11,7 @@ using TestContainers.Images;
 namespace TestContainers.Containers
 {
     /// <summary>
-    /// A docker container object
+    /// A docker container
     /// </summary>
     public interface IContainer
     {

--- a/src/TestContainers/Containers/IContainer.cs
+++ b/src/TestContainers/Containers/IContainer.cs
@@ -16,13 +16,7 @@ namespace TestContainers.Containers
     public interface IContainer
     {
         /// <summary>
-        /// Gets the image name
-        /// </summary>
-        [NotNull]
-        string DockerImageName { get; }
-
-        /// <summary>
-        /// Gets the docker image
+        /// Gets the docker image used for this container
         /// </summary>
         [NotNull]
         IImage DockerImage { get; }

--- a/src/TestContainers/Containers/IContainer.cs
+++ b/src/TestContainers/Containers/IContainer.cs
@@ -75,7 +75,7 @@ namespace TestContainers.Containers
         /// Command to run when the container starts
         /// </summary>
         [NotNull]
-        IList<string> Command { get; set; }
+        IList<string> Command { get; }
 
         /// <summary>
         /// Option to auto remove the container after use
@@ -85,12 +85,12 @@ namespace TestContainers.Containers
         /// <summary>
         /// Strategy to use to wait for services in the container to successfully start
         /// </summary>
-        IWaitStrategy WaitStrategy { get; }
+        IWaitStrategy WaitStrategy { get; set; }
 
         /// <summary>
         /// Strategy to use to wait for the container to start
         /// </summary>
-        IStartupStrategy StartupStrategy { get; }
+        IStartupStrategy StartupStrategy { get; set; }
 
         /// <summary>
         /// Starts the container

--- a/src/TestContainers/Containers/IContainer.cs
+++ b/src/TestContainers/Containers/IContainer.cs
@@ -28,7 +28,7 @@ namespace TestContainers.Containers
         IImage DockerImage { get; }
 
         /// <summary>
-        /// Gets the container id after it has started
+        /// Gets the container id after it has been created
         /// </summary>
         string ContainerId { get; }
 

--- a/src/TestContainers/Containers/IContainer.cs
+++ b/src/TestContainers/Containers/IContainer.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using TestContainers.Container.Abstractions.Images;
-using TestContainers.Container.Abstractions.Models;
+using TestContainers.Containers.Mounts;
+using TestContainers.Containers.StartupStrategies;
+using TestContainers.Containers.WaitStrategies;
+using TestContainers.Images;
 
 namespace TestContainers.Containers
 {
@@ -43,25 +45,27 @@ namespace TestContainers.Containers
         /// Dictionary&lt;int ExposedPort, int PortBinding&gt;
         /// </summary>
         [NotNull]
-        Dictionary<int, int> PortBindings { get; }
+        IDictionary<int, int> PortBindings { get; }
 
         /// <summary>
         /// Environment variables to be injected into the container
         /// Dictionary&lt;int key, int value&gt;
         /// </summary>
         [NotNull]
-        Dictionary<string, string> Env { get; }
+        IDictionary<string, string> Env { get; }
 
         /// <summary>
         /// Labels to be set on the container
         /// Dictionary&lt;int key, int value&gt;
         /// </summary>
-        Dictionary<string, string> Labels { get; }
+        [NotNull]
+        IDictionary<string, string> Labels { get; }
 
         /// <summary>
         /// List of path bindings between host and container
         /// </summary>
-        IList<Bind> BindMounts { get; }
+        [NotNull]
+        IList<IBind> BindMounts { get; }
 
         /// <summary>
         /// Sets the container to use privileged mode when this is set
@@ -83,6 +87,16 @@ namespace TestContainers.Containers
         /// Option to auto remove the container after use
         /// </summary>
         bool AutoRemove { get; set; }
+
+        /// <summary>
+        /// Strategy to use to wait for services in the container to successfully start
+        /// </summary>
+        IWaitStrategy WaitStrategy { get; }
+
+        /// <summary>
+        /// Strategy to use to wait for the container to start
+        /// </summary>
+        IStartupStrategy StartupStrategy { get; }
 
         /// <summary>
         /// Starts the container
@@ -110,7 +124,8 @@ namespace TestContainers.Containers
         /// </summary>
         /// <param name="exposedPort">Exposed port to map</param>
         /// <returns>The mapped port</returns>
-        /// <exception cref="InvalidOperationException">when the container has yet to start or port is not mapped</exception>
+        /// <exception cref="InvalidOperationException">when the container has yet to start</exception>
+        /// <exception cref="ArgumentException">when the port is not mapped</exception>
         int GetMappedPort(int exposedPort);
 
         /// <summary>
@@ -121,15 +136,5 @@ namespace TestContainers.Containers
         /// <returns>Tuple containing the response of the command</returns>
         /// <exception cref="InvalidOperationException">when the container has yet to start</exception>
         Task<(string stdout, string stderr)> ExecuteCommandAsync(string[] command, CancellationToken ct = default);
-
-        // /// <summary>
-        // /// Strategy to use to wait for services in the container to successfully start
-        // /// </summary>
-        // protected IWaitStrategy WaitStrategy { get; [NotNull] set; } = new NoWaitStrategy();
-
-        // /// <summary>
-        // /// Strategy to use to wait for the container to start
-        // /// </summary>
-        // protected IStartupStrategy StartupStrategy { get; [NotNull] set; } = new IsRunningStartupCheckStrategy();
     }
 }

--- a/src/TestContainers/Containers/Mounts/AccessMode.cs
+++ b/src/TestContainers/Containers/Mounts/AccessMode.cs
@@ -1,0 +1,28 @@
+namespace TestContainers.Containers.Mounts
+{
+    /// <summary>
+    /// Different access modes in bind mounting
+    /// </summary>
+    public class AccessMode
+    {
+        /// <summary>
+        /// ReadOnly access mode. AKA "ro"
+        /// </summary>
+        public static readonly AccessMode ReadOnly = new AccessMode("ro");
+
+        /// <summary>
+        /// ReadWrite access mode. AKA "rw"
+        /// </summary>
+        public static readonly AccessMode ReadWrite = new AccessMode("rw");
+
+        /// <summary>
+        /// String representation of the mode for docker client consumption
+        /// </summary>
+        public string Value { get; }
+
+        private AccessMode(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/TestContainers/Containers/Mounts/IBind.cs
+++ b/src/TestContainers/Containers/Mounts/IBind.cs
@@ -1,0 +1,23 @@
+namespace TestContainers.Containers.Mounts
+{
+    /// <summary>
+    /// Binding for mounts
+    /// </summary>
+    public interface IBind
+    {
+        /// <summary>
+        /// Absolute path to the folder to mount on the host machine
+        /// </summary>
+        string HostPath { get; }
+
+        /// <summary>
+        /// Absolute path to the folder to mount in the docker container
+        /// </summary>
+        string ContainerPath { get; }
+
+        /// <summary>
+        /// Sets the access mode of the mount
+        /// </summary>
+        AccessMode AccessMode { get; }
+    }
+}

--- a/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
+++ b/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Docker.DotNet;
+
+namespace TestContainers.Containers.StartupStrategies
+{
+    /// <summary>
+    /// Strategy to wait for the container to start
+    /// </summary>
+    public interface IStartupStrategy
+    {
+        /// <summary>
+        /// Wait for the container to start
+        /// </summary>
+        /// <param name="dockerClient">Docker client to use</param>
+        /// <param name="containerId">ContainerId to wait for</param>
+        /// <returns>Task that completes when the container starts successfully</returns>
+        Task WaitUntilSuccess(IDockerClient dockerClient, string containerId);
+    }
+}

--- a/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
+++ b/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet;
 
@@ -12,8 +13,9 @@ namespace TestContainers.Containers.StartupStrategies
         /// Wait for the container to start
         /// </summary>
         /// <param name="dockerClient">Docker client to use</param>
-        /// <param name="containerId">ContainerId to wait for</param>
+        /// <param name="container">Container to wait for</param>
+        /// <param name="ct">Cancellation token</param>
         /// <returns>Task that completes when the container starts successfully</returns>
-        Task WaitUntilSuccess(IDockerClient dockerClient, string containerId);
+        Task WaitUntilSuccess(IDockerClient dockerClient, IContainer container, CancellationToken ct = default);
     }
 }

--- a/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
+++ b/src/TestContainers/Containers/StartupStrategies/IStartupStrategy.cs
@@ -15,7 +15,7 @@ namespace TestContainers.Containers.StartupStrategies
         /// <param name="dockerClient">Docker client to use</param>
         /// <param name="container">Container to wait for</param>
         /// <param name="ct">Cancellation token</param>
-        /// <returns>Task that completes when the container starts successfully</returns>
+        /// <returns>Task that completes when the container started successfully</returns>
         Task WaitUntilSuccess(IDockerClient dockerClient, IContainer container, CancellationToken ct = default);
     }
 }

--- a/src/TestContainers/Containers/WaitStrategies/IWaitStrategy.cs
+++ b/src/TestContainers/Containers/WaitStrategies/IWaitStrategy.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet;
 
@@ -13,7 +14,8 @@ namespace TestContainers.Containers.WaitStrategies
         /// </summary>
         /// <param name="dockerClient">Docker client to use</param>
         /// <param name="container">Container to wait for</param>
+        /// <param name="ct">Cancellation token</param>
         /// <returns>Task that completes when the services started successfully</returns>
-        Task WaitUntil(IDockerClient dockerClient, IContainer container);
+        Task WaitUntil(IDockerClient dockerClient, IContainer container, CancellationToken ct = default);
     }
 }

--- a/src/TestContainers/Containers/WaitStrategies/IWaitStrategy.cs
+++ b/src/TestContainers/Containers/WaitStrategies/IWaitStrategy.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Docker.DotNet;
+
+namespace TestContainers.Containers.WaitStrategies
+{
+    /// <summary>
+    /// Strategy for waiting for services in the container to start
+    /// </summary>
+    public interface IWaitStrategy
+    {
+        /// <summary>
+        /// Wait for the services to start
+        /// </summary>
+        /// <param name="dockerClient">Docker client to use</param>
+        /// <param name="container">Container to wait for</param>
+        /// <returns>Task that completes when the services started successfully</returns>
+        Task WaitUntil(IDockerClient dockerClient, IContainer container);
+    }
+}

--- a/src/TestContainers/Core/Containers/IContainer.cs
+++ b/src/TestContainers/Core/Containers/IContainer.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using TestContainers.Container.Abstractions.Images;
+using TestContainers.Container.Abstractions.Models;
+
+namespace TestContainers.Containers
+{
+    /// <summary>
+    /// A docker container object
+    /// </summary>
+    public interface IContainer
+    {
+        /// <summary>
+        /// Gets the image name
+        /// </summary>
+        [NotNull]
+        string DockerImageName { get; }
+
+        /// <summary>
+        /// Gets the docker image
+        /// </summary>
+        [NotNull]
+        IImage DockerImage { get; }
+
+        /// <summary>
+        /// Gets the container id after it has started
+        /// </summary>
+        string ContainerId { get; }
+
+        /// <summary>
+        /// List of ports to be exposed on the container
+        /// These ports will be automatically mapped to a higher port upon container start
+        /// Use <see cref="GetMappedPort"/> to retrieve the automatically mapped port
+        /// </summary>
+        [NotNull]
+        IList<int> ExposedPorts { get; }
+
+        /// <summary>
+        /// Port bindings to create for the container. The port must also be exposed by Exposed ports.
+        /// Dictionary&lt;int ExposedPort, int PortBinding&gt;
+        /// </summary>
+        [NotNull]
+        Dictionary<int, int> PortBindings { get; }
+
+        /// <summary>
+        /// Environment variables to be injected into the container
+        /// Dictionary&lt;int key, int value&gt;
+        /// </summary>
+        [NotNull]
+        Dictionary<string, string> Env { get; }
+
+        /// <summary>
+        /// Labels to be set on the container
+        /// Dictionary&lt;int key, int value&gt;
+        /// </summary>
+        Dictionary<string, string> Labels { get; }
+
+        /// <summary>
+        /// List of path bindings between host and container
+        /// </summary>
+        IList<Bind> BindMounts { get; }
+
+        /// <summary>
+        /// Sets the container to use privileged mode when this is set
+        /// </summary>
+        bool IsPrivileged { get; set; }
+
+        /// <summary>
+        /// Sets the working directory after the container started
+        /// </summary>
+        string WorkingDirectory { get; set; }
+
+        /// <summary>
+        /// Command to run when the container starts
+        /// </summary>
+        [NotNull]
+        IList<string> Command { get; set; }
+
+        /// <summary>
+        /// Option to auto remove the container after use
+        /// </summary>
+        bool AutoRemove { get; set; }
+
+        /// <summary>
+        /// Starts the container
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>A task that completes when the container fully started</returns>
+        Task StartAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Stops the container
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>A task that completes when the container fully stops</returns>
+        Task StopAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets a network host address for this docker instance
+        /// </summary>
+        /// <returns>The network host for this docker instance</returns>
+        /// <exception cref="InvalidOperationException">when docker uses a transport that is not supported</exception>
+        string GetDockerHostIpAddress();
+
+        /// <summary>
+        /// Gets an mapped port from an exposed port
+        /// </summary>
+        /// <param name="exposedPort">Exposed port to map</param>
+        /// <returns>The mapped port</returns>
+        /// <exception cref="InvalidOperationException">when the container has yet to start or port is not mapped</exception>
+        int GetMappedPort(int exposedPort);
+
+        /// <summary>
+        /// Executes a command against a running container
+        /// </summary>
+        /// <param name="command">The command and its parameters to run</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Tuple containing the response of the command</returns>
+        /// <exception cref="InvalidOperationException">when the container has yet to start</exception>
+        Task<(string stdout, string stderr)> ExecuteCommandAsync(string[] command, CancellationToken ct = default);
+
+        // /// <summary>
+        // /// Strategy to use to wait for services in the container to successfully start
+        // /// </summary>
+        // protected IWaitStrategy WaitStrategy { get; [NotNull] set; } = new NoWaitStrategy();
+
+        // /// <summary>
+        // /// Strategy to use to wait for the container to start
+        // /// </summary>
+        // protected IStartupStrategy StartupStrategy { get; [NotNull] set; } = new IsRunningStartupCheckStrategy();
+    }
+}

--- a/src/TestContainers/Images/IImage.cs
+++ b/src/TestContainers/Images/IImage.cs
@@ -22,7 +22,7 @@ namespace TestContainers.Images
         /// Resolves this image into the local machine
         /// </summary>
         /// <param name="ct">cancellation token</param>
-        /// <returns>Task that completes when the image id has been resolved locally</returns>
+        /// <returns>Task that completes with the ImageId when the image has been resolved locally</returns>
         Task<string> Resolve(CancellationToken ct = default);
     }
 }

--- a/src/TestContainers/Images/IImage.cs
+++ b/src/TestContainers/Images/IImage.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestContainers.Images
+{
+    /// <summary>
+    /// A docker image
+    /// </summary>
+    public interface IImage
+    {
+        /// <summary>
+        /// Gets the image name
+        /// </summary>
+        string ImageName { get; }
+
+        /// <summary>
+        /// Gets the image id after it has been built or downloaded
+        /// </summary>
+        string ImageId { get; }
+
+        /// <summary>
+        /// Resolves this image into the local machine
+        /// </summary>
+        /// <param name="ct">cancellation token</param>
+        /// <returns>image id when the image is resolved locally</returns>
+        Task<string> Resolve(CancellationToken ct = default);
+    }
+}

--- a/src/TestContainers/Images/IImage.cs
+++ b/src/TestContainers/Images/IImage.cs
@@ -22,7 +22,7 @@ namespace TestContainers.Images
         /// Resolves this image into the local machine
         /// </summary>
         /// <param name="ct">cancellation token</param>
-        /// <returns>image id when the image is resolved locally</returns>
+        /// <returns>Task that completes when the image id has been resolved locally</returns>
         Task<string> Resolve(CancellationToken ct = default);
     }
 }

--- a/src/TestContainers/TestContainers.csproj
+++ b/src/TestContainers/TestContainers.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Docker.Dotnet" Version="3.125.2" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
     <PackageReference Include="MySql.Data" Version="6.10.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Npgsql" Version="4.0.2" />
@@ -11,5 +14,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
   </ItemGroup>
+  
   <Import Project="$(MSBuildThisFileDirectory)../../Shared.msbuild" />
+  
 </Project>


### PR DESCRIPTION
Draft PR to discuss how the `IContainer` interface should look like. There is missing code and models and I will fill it in once we decide on this interface.

Things I want to discuss:

1. [x] Should `WaitStrategy` and `StartupStrategy` be public (in the interface)
    - if they are not in the interface, they can only be customized by inheriting a new class
    - if they are in the interface, they can be customized by the builder
    - *Preference: public interface*
2. [x] `IList` or `List`
    - Makes no difference to me but arguably should be interface
    - If it's interface, then there are some methods in `List` that cannot be used
    - *Preference: `IList`*
3. [x] `IDictionary` or `Dictionary`
    - Same as `List`
    - *Preference: `IDictionary`*
4. [x] `Bind` class should be an interface as well?
    - *Preference: `IBind`*
5. [x] `GetMappedPort`. 
    - If exposed port is not mapped, should it throw `InvalidOperationException`, return null, or throw a different exception?
    - Method already throws `InvalidOperationException` if container is not yet started
    - *Preference: Throw `ArgumentException` instead*
6. [x] Namespaces
    - `TestContainers.Containers.IContainer`
    - `TestContainers.Containers.WaitStrategies.IWaitStrategy`
    - `TestContainers.Containers.StartupStrategies.IStartupStrategy`
    - `TestContainers.Containers.Mounts.IBind`
    - `TestContainers.Images.IImage`
    - `TestContainers.DockerClient`
    - `TestContainers.Builders`
    - Common stuff in `TestContainers`

 
If there are other things you want to discuss, please bring it up in another comment, and I'll consolidate the results in this top comment.