### PR TITLE
Feature/oracle xe container

### DIFF
--- a/src/TestContainers/Core/Builders/ContainerBuilder.cs
+++ b/src/TestContainers/Core/Builders/ContainerBuilder.cs
@@ -106,6 +106,17 @@ namespace TestContainers.Core.Builders
             return (TBuilder) this;
         }
 
+        public TBuilder WithShmSize(long shmSize)
+        {
+            fn = FnUtils.Compose(fn, (container) =>
+            {
+                container.ShmSize = shmSize;
+                return container;
+            });
+
+            return (TBuilder) this;
+        }
+
         public virtual TContainer Build() =>
             fn(null);
     }

--- a/src/TestContainers/Core/Containers/Container.cs
+++ b/src/TestContainers/Core/Containers/Container.cs
@@ -27,7 +27,8 @@ namespace TestContainers.Core.Containers
         public ContainerInspectResponse ContainerInspectResponse { get; set; }
         public (string SourcePath, string TargetPath, string Type)[] Mounts { get; set; }
         public string[] Commands { get; set; }
-
+        public long ShmSize { get; set; }
+        
         public Container() =>
             _dockerClient = DockerClientFactory.Instance.Client();
 
@@ -145,8 +146,10 @@ namespace TestContainers.Core.Containers
                         Type = m.Type,
                     }).ToList(),
                     PublishAllPorts = true,
+                    ShmSize = ShmSize
                 }
-            };
+
+                };
         }
 
         public async Task Stop()

--- a/src/TestContainers/Core/Containers/OracleXeContainer.cs
+++ b/src/TestContainers/Core/Containers/OracleXeContainer.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+using Polly;
+
+namespace TestContainers.Core.Containers
+{
+    public sealed class OracleXeContainer : DatabaseContainer
+    {
+        public const string IMAGE = "oracle/database";
+        public const string DEFAULT_TAG = "11.2.0.2-xe";
+        public const int ORACLE_PORT = 1521;
+
+        public override string DatabaseName => base.DatabaseName ?? _databaseName;
+
+        public override string UserName => base.UserName ?? _userName;
+
+        public override string Password => base.Password ?? _password;
+
+        string _databaseName = "test";
+        string _userName = "system";
+        string _password = "s3cr3t";
+
+        public override string ConnectionString => $"Data Source=(description=(address=(protocol=tcp)(host={GetDockerHostIpAddress()})(port={GetMappedPort(ORACLE_PORT)}))(connect_data=(sid=XE)));User Id={UserName};Password={Password};";
+
+        protected override string TestQueryString => "SELECT 1 FROM DUAL";
+
+        protected override async Task WaitUntilContainerStarted()
+        {
+            await base.WaitUntilContainerStarted();
+
+            var connection = new OracleConnection(ConnectionString);
+
+            var result = await Policy
+                .TimeoutAsync(TimeSpan.FromMinutes(4))
+                .WrapAsync(Policy
+                    .Handle<OracleException>()
+                    .Or<SocketException>()
+                    .WaitAndRetryForeverAsync(
+                        iteration => TimeSpan.FromSeconds(10)))
+                .ExecuteAndCaptureAsync(async () =>
+                {
+                    await connection.OpenAsync();
+
+                    var cmd = new OracleCommand(TestQueryString, connection);
+                    await cmd.ExecuteScalarAsync();
+                });
+
+            if (result.Outcome == OutcomeType.Failure)
+            {
+                connection.Dispose();
+                throw new Exception(result.FinalException.Message, result.FinalException);
+            }
+
+        }
+    }
+}

--- a/src/TestContainers/TestContainers.csproj
+++ b/src/TestContainers/TestContainers.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="MySql.Data" Version="6.10.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Npgsql" Version="4.0.2" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
     <PackageReference Include="Polly" Version="6.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />

--- a/test/TestContainers.Tests/ContainerTests/OracleXeTests.cs
+++ b/test/TestContainers.Tests/ContainerTests/OracleXeTests.cs
@@ -1,0 +1,46 @@
+using Xunit;
+using System.Threading.Tasks;
+using Npgsql;
+using Oracle.ManagedDataAccess.Client;
+using TestContainers.Core.Containers;
+using TestContainers.Core.Builders;
+
+namespace TestContainers.Tests.ContainerTests
+{
+    public class OracleXeFixture : IAsyncLifetime
+    {
+        public string ConnectionString => Container.ConnectionString;
+        OracleXeContainer Container { get; }
+
+        public OracleXeFixture() =>
+             Container = new DatabaseContainerBuilder<OracleXeContainer>()
+                .Begin()
+                .WithImage($"{OracleXeContainer.IMAGE}:{OracleXeContainer.DEFAULT_TAG}")
+                .WithExposedPorts(OracleXeContainer.ORACLE_PORT)
+                .WithEnv(("ORACLE_PWD", "s3cr3t"))
+                .WithShmSize(1024 * 1024 * 1024)
+                .Build();
+
+        public Task InitializeAsync() => Container.Start();
+
+        public Task DisposeAsync() => Container.Stop();
+    }
+
+    public class OracleXeTests : IClassFixture<OracleXeFixture>
+    {
+        readonly OracleConnection _connection;
+        public OracleXeTests(OracleXeFixture fixture) => _connection = new OracleConnection(fixture.ConnectionString);
+
+        [Fact]
+        public async Task SimpleTest()
+        {
+            const string query = "SELECT 1 FROM DUAL";
+            await _connection.OpenAsync();
+            var cmd = new OracleCommand(query, _connection);
+            var reader = (await cmd.ExecuteScalarAsync());
+            Assert.Equal(1.0m, reader);
+
+            _connection.Close();
+        }
+    }
+}

--- a/test/TestContainers.Tests/TestContainers.Tests.csproj
+++ b/test/TestContainers.Tests/TestContainers.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="coverlet.msbuild" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds the OracleXe database as Testcontainer.

To be able to use OracleXe, there is the need to configure the shared memory value (ShmSize) of the container.
I extended the Container and ContainerBuilder to set this value.