### PR TITLE
#80 Add NuGet prereleases for develop builds (#81)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ for:
   branches:
     only:
       - master
+      - develop
   before_deploy:
     - sh: ./build.sh --target=Create-NuGet-Packages
   deploy_script:

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@
 
 #addin nuget:?package=Cake.Sonar&version=1.1.22
 
-#addin nuget:?package=Cake.Git&version=0.20.0
+#addin nuget:?package=Cake.Git&version=0.21.0
 
 #load "./build/parameters.cake"
 
@@ -119,6 +119,7 @@ Task("Sonar-End")
 });
 
 Task("Create-NuGet-Packages")
+  .WithCriteria(() => param.ShouldPublish)
   .Does(() =>
 {
   DotNetCorePack(param.Projects.Testcontainers.Path.FullPath, new DotNetCorePackSettings

--- a/build/credentials.cake
+++ b/build/credentials.cake
@@ -58,4 +58,15 @@ internal class NuGetCredentials : BuildCredentials
       context.EnvironmentVariable("NUGET_APIKEY")
     );
   }
+
+  public static NuGetCredentials GetNuGetPrereleaseCredentials(ICakeContext context)
+  {
+    return new NuGetCredentials
+    (
+      context.EnvironmentVariable("NUGET_PRERELEASE_USERNAME") ?? "",
+      context.EnvironmentVariable("NUGET_PRERELEASE_PASSWORD") ?? "",
+      context.EnvironmentVariable("NUGET_PRERELEASE_SOURCE"),
+      context.EnvironmentVariable("NUGET_PRERELEASE_APIKEY")
+    );
+  }
 }

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -38,12 +38,18 @@ internal class BuildParameters
       Configuration = context.Argument("configuration", "master".Equals(branch) ? "Release" : "Debug"),
       Version = version,
       Branch = branch,
-      ShouldPublish = "master".Equals(branch),
+      ShouldPublish = ShouldPublishing(branch),
       Verbosity = DotNetCoreVerbosity.Quiet,
       SonarQubeCredentials = SonarQubeCredentials.GetSonarQubeCredentials(context),
-      NuGetCredentials = NuGetCredentials.GetNuGetCredentials(context),
+      NuGetCredentials = "master".Equals(branch) ? NuGetCredentials.GetNuGetCredentials(context) : NuGetCredentials.GetNuGetPrereleaseCredentials(context),
       Projects = BuildProjects.Instance(context, solution),
       Paths = BuildPaths.Instance(context, version)
     };
+  }
+
+  public static bool ShouldPublishing(string branch)
+  {
+    var branches = new [] { "master", "develop" };
+    return branches.Any(b => StringComparer.OrdinalIgnoreCase.Equals(b, branch));
   }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.33.0" />
+  <package id="Cake" version="0.36.0" />
 </packages>


### PR DESCRIPTION
@swissarmykirpan could you add the environment variables? I still can not change the Appveyor project settings.

- [x] `NUGET_PRERELEASE_SOURCE`
- [x] `NUGET_PRERELEASE_APIKEY` 